### PR TITLE
Subtle toggle icon

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -4,8 +4,8 @@
     transform: rotate(90deg);
     transform-origin: top left;
     position: relative;
-    height: 42px;
-    left: 42px;
+    height: 40px;
+    left: 40px;
 }
 
 /* hide everything in a closed list... */
@@ -20,12 +20,12 @@
 
 /* we need to reduce the width of the title to fit the collapse toggle in */
 .js-list .list .list-header-name {
-    width: calc(100% - 22px);
+    width: calc(100% - 20px);
 }
 
 /* collapsed list header - rotated + some css hackery to make it look right */
 .js-list.-closed .list .list-header-name {
-    height: 40px !important;
+    height: 38px !important;
     width: auto;
     line-height: 30px;
     display: block !important;

--- a/styles.css
+++ b/styles.css
@@ -39,13 +39,11 @@
 .collapse-toggle {
     float: left;
     cursor: pointer;
-    background: white;
-    border: 1px solid #ccc;
-    border-radius: 50%;
     height: 20px;
     width: 20px;
     text-align: center;
     position: relative;
+    opacity: 0.5;
 }
 
 /* collapse toggle button - triangle */


### PR DESCRIPTION
*Part of a set of PRs: subtle icons #3, autohiding #4, or both #5.*

I found the default black-on-white-circle toggle icon a bit too intrusive (my intent behind collapsing lists is having less clutter, after all), so here's a patch that replaces them with a more subtle backgroundless triangle:

![subtle-icon](https://user-images.githubusercontent.com/2692085/53489244-ff091e00-3a90-11e9-8d05-b3f866190c36.png)
