### PR TITLE
Only show toggle icon when hovering over list header

### DIFF
--- a/script.js
+++ b/script.js
@@ -12,7 +12,7 @@ if (!document.querySelector('.collapse-toggle')) {
                 e.parentNode.parentNode.parentNode.classList.add('-closed');
             // create toggle button
             var toggle = document.createElement("div");
-            toggle.className = 'collapse-toggle';
+            toggle.className = 'collapse-toggle collapse-toggle-hidden';
             // toggle click handler
             toggle.addEventListener('click', evt => {
                 // get column name from event target
@@ -22,6 +22,14 @@ if (!document.querySelector('.collapse-toggle')) {
                     // toggle the -closed class on successful save
                     evt.target.parentNode.parentNode.parentNode.classList.toggle('-closed');
                 });
+            })
+            e.parentNode.addEventListener('mouseover', evt => {
+                // show toggle icon
+                $(evt.target.parentNode).find('.collapse-toggle').removeClass('collapse-toggle-hidden');
+            })
+            e.parentNode.addEventListener('mouseout', evt => {
+                // hide toggle icon
+                $(evt.target.parentNode).find('.collapse-toggle').addClass('collapse-toggle-hidden');
             })
             e.parentNode.parentNode.parentNode.setAttribute('draggable', true);
             // insert toggle button

--- a/styles.css
+++ b/styles.css
@@ -71,3 +71,8 @@
     left: 8px;
     top: 5px;
 }
+
+/* collapse toggle button - helper class for hiding */
+.collapse-toggle-hidden {
+    display: none;
+}

--- a/styles.css
+++ b/styles.css
@@ -13,9 +13,14 @@
     display: none !important;
 }
 
-/* ...except for the title and the collapse toggle */
-.js-list.-closed .list .list-header, .js-list.-closed .list .collapse-toggle {
+/* ...except for the title and the collapse toggle (if appropriate) */
+.js-list.-closed .list .list-header, .js-list.-closed .list .collapse-toggle:not(.collapse-toggle-hidden) {
     display: block !important;
+}
+
+/* collapse toggle button - helper class for hiding */
+.collapse-toggle-hidden {
+    display: none;
 }
 
 /* we need to reduce the width of the title to fit the collapse toggle in */
@@ -33,6 +38,11 @@
     background: #E2E4E6;
     left: 36px;
     top: 4px;
+}
+
+/* shift list title upwards (i.e. close the gap) when toggle icon is hidden */
+.js-list.-closed .list .collapse-toggle-hidden ~ .list-header-name {
+    left: 8px;
 }
 
 /* collapse toggle button */
@@ -70,9 +80,4 @@
     border-right: none;
     left: 8px;
     top: 5px;
-}
-
-/* collapse toggle button - helper class for hiding */
-.collapse-toggle-hidden {
-    display: none;
 }


### PR DESCRIPTION
*Part of a set of PRs: subtle icons #3, autohiding #4, or both #5.*

I found it a bit too intrusive to have an icons to the left of each list title all the time (my intent behind collapsing lists is having less clutter, after all), so here's a patch to hide the icons by default and only show them when the mouse is hovered over a list header.
