### PR TITLE
Subtle toggle icon + Only show toggle icon when hovering over list header

### DIFF
--- a/script.js
+++ b/script.js
@@ -12,7 +12,7 @@ if (!document.querySelector('.collapse-toggle')) {
                 e.parentNode.parentNode.parentNode.classList.add('-closed');
             // create toggle button
             var toggle = document.createElement("div");
-            toggle.className = 'collapse-toggle';
+            toggle.className = 'collapse-toggle collapse-toggle-hidden';
             // toggle click handler
             toggle.addEventListener('click', evt => {
                 // get column name from event target
@@ -22,6 +22,14 @@ if (!document.querySelector('.collapse-toggle')) {
                     // toggle the -closed class on successful save
                     evt.target.parentNode.parentNode.parentNode.classList.toggle('-closed');
                 });
+            })
+            e.parentNode.addEventListener('mouseover', evt => {
+                // show toggle icon
+                $(evt.target.parentNode).find('.collapse-toggle').removeClass('collapse-toggle-hidden');
+            })
+            e.parentNode.addEventListener('mouseout', evt => {
+                // hide toggle icon
+                $(evt.target.parentNode).find('.collapse-toggle').addClass('collapse-toggle-hidden');
             })
             e.parentNode.parentNode.parentNode.setAttribute('draggable', true);
             // insert toggle button

--- a/styles.css
+++ b/styles.css
@@ -69,3 +69,8 @@
     left: 8px;
     top: 5px;
 }
+
+/* collapse toggle button - helper class for hiding */
+.collapse-toggle-hidden {
+    display: none;
+}

--- a/styles.css
+++ b/styles.css
@@ -4,8 +4,8 @@
     transform: rotate(90deg);
     transform-origin: top left;
     position: relative;
-    height: 42px;
-    left: 42px;
+    height: 40px;
+    left: 40px;
 }
 
 /* hide everything in a closed list... */
@@ -20,12 +20,12 @@
 
 /* we need to reduce the width of the title to fit the collapse toggle in */
 .js-list .list .list-header-name {
-    width: calc(100% - 22px);
+    width: calc(100% - 20px);
 }
 
 /* collapsed list header - rotated + some css hackery to make it look right */
 .js-list.-closed .list .list-header-name {
-    height: 40px !important;
+    height: 38px !important;
     width: auto;
     line-height: 30px;
     display: block !important;

--- a/styles.css
+++ b/styles.css
@@ -13,9 +13,14 @@
     display: none !important;
 }
 
-/* ...except for the title and the collapse toggle */
-.js-list.-closed .list .list-header, .js-list.-closed .list .collapse-toggle {
+/* ...except for the title and the collapse toggle (if appropriate) */
+.js-list.-closed .list .list-header, .js-list.-closed .list .collapse-toggle:not(.collapse-toggle-hidden) {
     display: block !important;
+}
+
+/* collapse toggle button - helper class for hiding */
+.collapse-toggle-hidden {
+    display: none;
 }
 
 /* we need to reduce the width of the title to fit the collapse toggle in */
@@ -33,6 +38,11 @@
     background: #E2E4E6;
     left: 36px;
     top: 4px;
+}
+
+/* shift list title upwards (i.e. close the gap) when toggle icon is hidden */
+.js-list.-closed .list .collapse-toggle-hidden ~ .list-header-name {
+    left: 8px;
 }
 
 /* collapse toggle button */
@@ -68,9 +78,4 @@
     border-right: none;
     left: 8px;
     top: 5px;
-}
-
-/* collapse toggle button - helper class for hiding */
-.collapse-toggle-hidden {
-    display: none;
 }

--- a/styles.css
+++ b/styles.css
@@ -39,13 +39,11 @@
 .collapse-toggle {
     float: left;
     cursor: pointer;
-    background: white;
-    border: 1px solid #ccc;
-    border-radius: 50%;
     height: 20px;
     width: 20px;
     text-align: center;
     position: relative;
+    opacity: 0.5;
 }
 
 /* collapse toggle button - triangle */


### PR DESCRIPTION
*Part of a set of PRs: subtle icons #3, autohiding #4, or both #5.*

This PR combines #3 and #4: use a subtle toggle icon, and only show it when the mouse is hovering over a list header.